### PR TITLE
feat: encapsulate properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ composer require laravel-css-inliner/css-inliner
 
 ## Usage
 
-For the purpose of this demsonstration we'll use the facade `LaravelCssInliner\Facades\CssInline`, however if you prefer directly using the instance (like myself) you can swap `LaravelCssInliner\Facades\CssInline::` out for `LaravelCssInliner\CssInliner::singleton()->` in any of the examples below. 
+For the purpose of this demonstration we'll use the facade `LaravelCssInliner\Facades\CssInline`, however if you prefer directly using the instance (like myself) you can swap `LaravelCssInliner\Facades\CssInline::` out for `LaravelCssInliner\CssInliner::singleton()->` in any of the examples below. 
 
 #### Adding CSS via PHP
 

--- a/src/CssInliner.php
+++ b/src/CssInliner.php
@@ -42,23 +42,10 @@ class CssInliner
     protected array $interceptCssFiles = [];
 
     /** Is debug mode enabled? */
-    protected static bool $debug = false;
+    protected bool $debug = false;
 
     /** @var array<string> Debug logs */
-    protected static array $log = [];
-
-    /**
-     * Create a new CssInliner instance
-     *
-     * For Laravel: it's recommended you use the facade
-     * or at least `app(CssInliner::class)` to ensure that
-     * you're also referencing a singleton not a stray
-     * instance
-     */
-    public static function create(): self
-    {
-        return new self();
-    }
+    protected array $log = [];
 
     public function __construct()
     {
@@ -68,25 +55,25 @@ class CssInliner
     /**
      * Enable debug mode
      */
-    public static function enableDebug(): void
+    public function enableDebug(): void
     {
-        static::$debug = true;
+        $this->debug = true;
     }
 
     /**
      * Disable debug mode
      */
-    public static function disableDebug(): void
+    public function disableDebug(): void
     {
-        static::$debug = false;
+        $this->debug = false;
     }
 
     /**
      * Reset the log
      */
-    public static function flushDebugLog(): void
+    public function flushDebugLog(): void
     {
-        static::$log = [];
+        $this->log = [];
     }
 
     /**
@@ -94,9 +81,9 @@ class CssInliner
      *
      * @return array<string>
      */
-    public static function getDebugLog(): array
+    public function getDebugLog(): array
     {
-        return static::$log;
+        return $this->log;
     }
 
     /**
@@ -104,7 +91,7 @@ class CssInliner
      */
     public function debug(string $message): self
     {
-        if (static::$debug) {
+        if ($this->debug) {
             $log = sprintf(
                 '[%s]: %s | %s',
                 Carbon::now()->toDateTimeString(),
@@ -112,7 +99,7 @@ class CssInliner
                 $message,
             );
 
-            static::$log[] = $log;
+            $this->log[] = $log;
         }
 
         return $this;

--- a/src/Facades/CssInline.php
+++ b/src/Facades/CssInline.php
@@ -11,8 +11,12 @@ use Symfony\Component\Mime\Email;
 /**
  * @mixin CssInliner
  *
+ * @method static void enableDebug()
+ * @method static void disableDebug()
+ * @method static void flushDebugLog()
+ * @method static array getDebugLog()
  * @method static CssInliner debug(string $message)
- * @method static CssInliner addCss(string|SplFileInfo $file)
+ * @method static CssInliner addCss(string|SplFileInfo $css)
  * @method static CssInliner addCssPath(string|SplFileInfo $file)
  * @method static CssInliner addCssRaw(string $css)
  * @method static CssInliner clearCss()
@@ -31,6 +35,7 @@ use Symfony\Component\Mime\Email;
  * @method static CssInliner clearInterceptors()
  * @method static Email convertEmail(Email $email)
  * @method static string convert(string $html)
+ * @method static void stripCssFromHtml(string &$html)
  * @method static string parseCssFromHtml(string &$html)
  * @method static CssInliner beforeConvertingEmail(callable $callback)
  * @method static CssInliner afterConvertingEmail(callable $callback)
@@ -39,7 +44,7 @@ use Symfony\Component\Mime\Email;
  * @method static CssInliner instance()
  * @method static array cssFiles()
  * @method static array cssRaw()
- * @method static void halt()
+ * @method static false halt()
  */
 class CssInline extends Facade
 {

--- a/tests/Feature/ConvertTest.php
+++ b/tests/Feature/ConvertTest.php
@@ -10,7 +10,7 @@ it('can convert css classes to inline styles using raw CSS', function () {
 
     $expect = 'This is a <span class="font-bold" style="font-weight: bold;">test</span>';
 
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->addCssRaw($css)
         ->convert($html);
 
@@ -24,7 +24,7 @@ it('can convert css classes to inline styles using CSS file', function () {
     $html = 'This is a <span class="font-bold">test</span>';
     $expect = 'This is a <span class="font-bold" style="font-weight: bold;">test</span>';
 
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->addCssPath($file)
         ->convert($html);
 
@@ -37,7 +37,7 @@ it('can convert css classes to inline styles using embedded style element', func
 
     $expect = 'This is a <span class="example" style="text-decoration: underline;">test</span>';
 
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->enableCssExtractionFromHtmlContent()
         ->disableCssRemovalFromHtmlContent()
         ->convert($html);
@@ -52,7 +52,7 @@ it('can convert css classes to inline styles using embedded link element as loca
 
     $expect = 'This is a <span class="example" style="font-style: italic;">test</span>';
 
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->enableCssExtractionFromHtmlContent()
         ->disableCssRemovalFromHtmlContent()
         ->convert($html);
@@ -71,7 +71,7 @@ it('can convert css classes to inline styles using multiple sources', function (
 
     $expect = 'This is a <span class="example" style="font-weight: bold; font-size: 12px; color: red; text-decoration: underline;">test</span>';
 
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->addCssPath($file1)
         ->addCssPath($file2)
         ->addCssRaw($css1)
@@ -114,7 +114,7 @@ it('can convert css classes to inline styles and remove style and link elements 
     /**
      * Enabled
      */
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->enableCssExtractionFromHtmlContent()
         ->enableCssRemovalFromHtmlContent()
         ->convert($html);
@@ -130,7 +130,7 @@ it('can convert css classes to inline styles and remove style and link elements 
     /**
      * Disabled
      */
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->enableCssExtractionFromHtmlContent()
         ->disableCssRemovalFromHtmlContent()
         ->convert($html);
@@ -177,7 +177,7 @@ it('will not parse css style and link elements from html if disabled', function 
     /**
      * Enabled
      */
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->enableCssExtractionFromHtmlContent()
         ->disableCssRemovalFromHtmlContent()
         ->convert($html);
@@ -188,7 +188,7 @@ it('will not parse css style and link elements from html if disabled', function 
     /**
      * Disabled
      */
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->disableCssExtractionFromHtmlContent()
         ->disableCssRemovalFromHtmlContent()
         ->convert($html);

--- a/tests/Feature/EventsTest.php
+++ b/tests/Feature/EventsTest.php
@@ -24,7 +24,7 @@ it('will fire events when converting HTML', function () {
         PostEmailCssInlineEvent::class => 0,
     ];
 
-    CssInliner::create()
+    $this->app->make(CssInliner::class)
         ->addCssRaw($css)
         ->beforeConvertingHtml(function (string $eventHtml, CssInliner $eventInliner, PreCssInlineEvent $event) use ($html, $css, &$callbacks) {
             $callbacks[PreCssInlineEvent::class]++;
@@ -67,7 +67,7 @@ it('will fire events when converting an email', function () {
         PostEmailCssInlineEvent::class => 0,
     ];
 
-    CssInliner::create()
+    $this->app->make(CssInliner::class)
         ->addCssRaw($css = '.font-bold { font-weight: bold; }')
         ->beforeConvertingEmail(function (Email $eventEmail, CssInliner $eventInliner, PreEmailCssInlineEvent $event) use ($html, $email, $css, &$callbacks) {
             $callbacks[PreEmailCssInlineEvent::class]++;
@@ -136,7 +136,7 @@ it('will fire events to multiple listeners when converting an email', function (
         PostEmailCssInlineEvent::class => 0,
     ];
 
-    CssInliner::create()
+    $this->app->make(CssInliner::class)
         ->beforeConvertingEmail(function (Email $eventEmail, CssInliner $eventInliner, PreEmailCssInlineEvent $event) use (&$callbacks) {
             $callbacks[PreEmailCssInlineEvent::class]++;
         })
@@ -175,7 +175,7 @@ it('will allow modification of html during pre and post events', function () {
     $html = 'Test<span class="font-bold">Test</span>Test';
 
     $expect = 'Test<span class="font-bold" style="font-weight: bold;">Test</span>Test';
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->beforeConvertingHtml(fn (string & $eventHtml, CssInliner $eventInliner, PreCssInlineEvent $event) => $eventHtml .= 'something1')
         ->beforeConvertingHtml(fn (string & $eventHtml, CssInliner $eventInliner, PreCssInlineEvent $event) => $eventInliner->debug('ran_second_event'))
         ->afterConvertingHtml(fn (string & $eventHtml, CssInliner $eventInliner, PostCssInlineEvent $event) => $eventHtml .= 'something2')
@@ -204,7 +204,7 @@ it('will allow halting of html conversion by halting css inliner', function () {
     $html = 'Test<span class="font-bold">Test</span>Test';
 
     $expect = $html;
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->beforeConvertingHtml(fn (string $eventHtml, CssInliner $eventInliner, PreCssInlineEvent $event) => $eventInliner->halt())
         ->beforeConvertingHtml(fn (string $eventHtml, CssInliner $eventInliner, PreCssInlineEvent $event) => $eventInliner->debug('ran_second_event'))
         ->addCssRaw($css)
@@ -227,7 +227,7 @@ it('will allow halting of email conversion by halting css inliner', function () 
 
     $expect = $html;
 
-    $actual = CssInliner::create()
+    $actual = $this->app->make(CssInliner::class)
         ->beforeConvertingEmail(fn (Email $eventEmail, CssInliner $eventInliner, PreEmailCssInlineEvent $event) => $eventInliner->halt())
         ->beforeConvertingHtml(fn (Email $eventEmail, CssInliner $eventInliner, PreEmailCssInlineEvent $event) => $eventInliner->debug('ran_second_event'))
         ->addCssRaw($css)
@@ -287,7 +287,7 @@ it('will allow halting of html conversion by halting css inliner but will allow 
         ->and('ran_second_event')->debugLogNotExists()
         ->and('html_conversion_finished')->debugLogNotExists();
 
-    CssInliner::flushDebugLog();
+    CssInline::flushDebugLog();
 
     $html = 'Test<span class="font-bold">Test second</span>Test';
     $expect = 'Test<span class="font-bold" style="font-weight: bold;">Test second</span>Test';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaravelCssInliner\Tests;
 
-use LaravelCssInliner\CssInliner;
+use LaravelCssInliner\Facades\CssInline;
 use LaravelCssInliner\LaravelCssInlinerServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
@@ -24,11 +24,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::setUp();
 
-        CssInliner::enableDebug();
-        CssInliner::flushDebugLog();
-
-        // New instance
-        app()->singleton(CssInliner::class, fn () => new CssInliner());
+        CssInline::enableDebug();
+        CssInline::flushDebugLog();
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As this package is bound as a singleton, and also just for general benefits, it's good to ensure that the property is encapsulated into the instance. 👍🏻 This changes the static variables and methods to be non-static, and also removes the `create()` method.

The reason I've removed the `create()` method is that this is a Laravel package, so it makes sense to always resolve via DI / the Facade. 👍🏻

- [x] I have read the **[CONTRIBUTING](https://github.com/LaravelCssInliner/skeleton-php/blob/main/.github/CONTRIBUTING.md)** document.
