### PR TITLE
feat: use PSR logger

### DIFF
--- a/tests/Feature/EventsTest.php
+++ b/tests/Feature/EventsTest.php
@@ -51,8 +51,12 @@ it('will fire events when converting HTML', function () {
     expect($callbacks[PreEmailCssInlineEvent::class])->toBe(0)
         ->and($callbacks[PreCssInlineEvent::class])->toBe(1)
         ->and($callbacks[PostCssInlineEvent::class])->toBe(1)
-        ->and($callbacks[PostEmailCssInlineEvent::class])->toBe(0)
-        ->and('html_conversion_finished')->debugLogExists();
+        ->and($callbacks[PostEmailCssInlineEvent::class])->toBe(0);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'html_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });
 
 it('will fire events when converting an email', function () {
@@ -120,8 +124,12 @@ it('will fire events when converting an email', function () {
     expect($callbacks[PreEmailCssInlineEvent::class])->toBe(1)
         ->and($callbacks[PreCssInlineEvent::class])->toBe(1)
         ->and($callbacks[PostCssInlineEvent::class])->toBe(1)
-        ->and($callbacks[PostEmailCssInlineEvent::class])->toBe(1)
-        ->and('email_conversion_finished')->debugLogExists();
+        ->and($callbacks[PostEmailCssInlineEvent::class])->toBe(1);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'email_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });
 
 it('will fire events to multiple listeners when converting an email', function () {
@@ -166,8 +174,12 @@ it('will fire events to multiple listeners when converting an email', function (
     expect($callbacks[PreEmailCssInlineEvent::class])->toBe(2)
         ->and($callbacks[PreCssInlineEvent::class])->toBe(2)
         ->and($callbacks[PostCssInlineEvent::class])->toBe(2)
-        ->and($callbacks[PostEmailCssInlineEvent::class])->toBe(2)
-        ->and('email_conversion_finished')->debugLogExists();
+        ->and($callbacks[PostEmailCssInlineEvent::class])->toBe(2);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'email_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });
 
 it('will allow modification of html during pre and post events', function () {
@@ -194,9 +206,17 @@ it('will allow modification of html during pre and post events', function () {
         subject: $actual,
     );
 
-    expect($actual)->sameHtml($expect)
-        ->and('html_conversion_finished')->debugLogExists()
-        ->and('ran_second_event')->debugLogExists();
+    expect($actual)->sameHtml($expect);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'html_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'ran_second_event',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });
 
 it('will allow halting of html conversion by halting css inliner', function () {
@@ -211,11 +231,27 @@ it('will allow halting of html conversion by halting css inliner', function () {
         ->convert($html);
 
     // No change
-    expect($actual)->sameHtml($expect)
-        ->and('html_processing_has_been_halted_skipping_conversion')->debugLogExists()
-        ->and('email_processing_has_been_halted_skipping_conversion')->debugLogNotExists()
-        ->and('ran_second_event')->debugLogNotExists()
-        ->and('email_conversion_finished')->debugLogNotExists();
+    expect($actual)->sameHtml($expect);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'html_processing_has_been_halted_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'email_processing_has_been_halted_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'ran_second_event',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'email_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });
 
 it('will allow halting of email conversion by halting css inliner', function () {
@@ -234,11 +270,27 @@ it('will allow halting of email conversion by halting css inliner', function () 
         ->convertEmail($email);
 
     // No change
-    expect($actual->getHtmlBody())->sameHtml($expect)
-        ->and('email_processing_has_been_halted_skipping_conversion')->debugLogExists()
-        ->and('html_processing_has_been_halted_skipping_conversion')->debugLogNotExists()
-        ->and('ran_second_event')->debugLogNotExists()
-        ->and('email_conversion_finished')->debugLogNotExists();
+    expect($actual->getHtmlBody())->sameHtml($expect);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'email_processing_has_been_halted_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'html_processing_has_been_halted_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'ran_second_event',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'email_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });
 
 it('listens to laravel mail sending event', function () {
@@ -263,9 +315,17 @@ it('listens to laravel mail sending event', function () {
 
     expect($preEmail)->toBe($email)
         ->and($postEmail)->toBe($email)
-        ->and($email->getHtmlBody())->sameHtml($expect)
-        ->and('email_listener_is_disabled_skipping_conversion')->debugLogNotExists()
-        ->and('email_conversion_finished')->debugLogExists();
+        ->and($email->getHtmlBody())->sameHtml($expect);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'email_listener_is_disabled_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'email_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });
 
 it('will allow halting of html conversion by halting css inliner but will allow subsequent conversions', function () {
@@ -281,13 +341,27 @@ it('will allow halting of html conversion by halting css inliner but will allow 
         ->convert($html);
 
     // No change
-    expect($actual)->sameHtml($expect)
-        ->and('html_processing_has_been_halted_skipping_conversion')->debugLogExists()
-        ->and('email_processing_has_been_halted_skipping_conversion')->debugLogNotExists()
-        ->and('ran_second_event')->debugLogNotExists()
-        ->and('html_conversion_finished')->debugLogNotExists();
+    expect($actual)->sameHtml($expect);
 
-    CssInline::flushDebugLog();
+    $this->logger->shouldHaveReceived('debug', [
+        'html_processing_has_been_halted_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'email_processing_has_been_halted_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'ran_second_event',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'html_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 
     $html = 'Test<span class="font-bold">Test second</span>Test';
     $expect = 'Test<span class="font-bold" style="font-weight: bold;">Test second</span>Test';
@@ -297,9 +371,17 @@ it('will allow halting of html conversion by halting css inliner but will allow 
         ->convert($html);
 
     // No change
-    expect($actual)->sameHtml($expect)
-        ->and('html_processing_has_been_halted_skipping_conversion')->debugLogNotExists()
-        ->and('html_conversion_finished')->debugLogExists();
+    expect($actual)->sameHtml($expect);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'html_processing_has_been_halted_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldHaveReceived('debug', [
+        'html_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });
 
 it('listens to laravel mail sending event but ignores event if disabled', function () {
@@ -328,6 +410,13 @@ it('listens to laravel mail sending event but ignores event if disabled', functi
         ->and($postEmail)->toBeNull()
         ->and($email->getHtmlBody())->sameHtml($expect);
 
-    expect('email_listener_is_disabled_skipping_conversion')->debugLogExists()
-        ->and('email_conversion_finished')->debugLogNotExists();
+    $this->logger->shouldHaveReceived('debug', [
+        'email_listener_is_disabled_skipping_conversion',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
+
+    $this->logger->shouldNotHaveReceived('debug', [
+        'email_conversion_finished',
+        ['instance' => $this->app->make(CssInliner::class)->instanceId],
+    ]);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use LaravelCssInliner\Facades\CssInline;
 use LaravelCssInliner\Tests\TestCase;
 
 uses(TestCase::class)->in('Feature');
@@ -38,40 +37,4 @@ expect()->extend('sameHtml', function (string $html) {
     expect(cleanHtml($this->value))->toBe(cleanHtml($html));
 
     return $this;
-});
-
-expect()->extend('debugLogExists', function () {
-    /** @var \Pest\Expectation $this */
-    $logs = collect(CssInline::getDebugLog())
-        ->map(fn (string $log) => explode(' | ', $log)[1])
-        ->map(fn (string $log) => preg_split('/[:,]/', $log))
-        ->toArray();
-
-    $expect = $this->value;
-
-    if (! is_array($expect)) {
-        $expect = [$expect];
-    }
-
-    foreach ($logs as $log) {
-        if ($log[0] === $expect[0]) {
-            // found
-
-            foreach ($expect as $part => $expectValue) {
-                expect($log[$part])->toBe($expectValue);
-            }
-
-            return $this;
-        }
-    }
-
-    // Will fail but that's fine; we just want a relevant error
-    expect($logs)->toContain($expect);
-
-    return $this;
-});
-
-expect()->extend('debugLogNotExists', function () {
-    /** @var \Pest\Expectation $this */
-    return $this->not()->debugLogExists();
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace LaravelCssInliner\Tests;
 
-use LaravelCssInliner\Facades\CssInline;
 use LaravelCssInliner\LaravelCssInlinerServiceProvider;
+use Mockery;
+use Mockery\MockInterface;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
+    protected Logger|MockInterface $logger;
+
     protected function getPackageProviders($app): array
     {
         return [LaravelCssInlinerServiceProvider::class];
@@ -16,25 +21,25 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function getPackageAliases($app): array
     {
-        return [
-        ];
+        return [];
     }
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        CssInline::enableDebug();
-        CssInline::flushDebugLog();
+        $this->logger = Mockery::spy(Logger::class);
+
+        $this->app->singleton(LoggerInterface::class, fn () => $this->logger);
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
 
-        foreach (scandir(__DIR__.'/.temp') as $file) {
+        foreach (scandir(__DIR__.'/.temp') ?: [] as $file) {
             if ($file[0] !== '.') {
-                unlink(__DIR__.'/.temp/'.$file);
+                unlink(__DIR__."/.temp/{$file}");
             }
         }
     }

--- a/tests/idehelper.php
+++ b/tests/idehelper.php
@@ -4,8 +4,6 @@ namespace Pest;
 
 /**
  * @method self sameHtml(string $html) Assert the given HTML matches (excl doctype, head, body, etc)
- * @method self debugLogExists() Assert that the actual value exists in the CssInliner debug logs
- * @method self debugLogNotExists() Assert that the actual value does not exist in the CssInliner debug logs
  */
 class Expectation
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This updates to use the PSR logger interface for logging, rather than a custom implementation. This is simpler, reduces the logic in the `debug()` method, and allows better logging to specific locations.

As it calls the `LoggerInterface::debug()` method, we no longer need to have a property to declare whether it should debug.

In the tests, I'm using a Mockery Spy, this means we can ensure that specific debug messages are or are not called in the same way. 👍🏻

By default, it will use a `NullLogger`, or the `LoggerInterface` provided from Laravel's container.

- [x] I have read the **[CONTRIBUTING](https://github.com/laravel-css-inliner/css-inliner/blob/main/.github/CONTRIBUTING.md)** document.
